### PR TITLE
Added cache buster query param to radar image

### DIFF
--- a/modules/accuweatherradar.js
+++ b/modules/accuweatherradar.js
@@ -69,14 +69,16 @@ function Radar() {
 
   this.getRadarByZip = function(zip, callback) {
     var lookup = zipcodes.lookup(zip);
+
     if (!lookup) {
       var error = new Error('Could not find zipcode');
       error.status = 404;
       callback(error, null);
     } else {
+      var cachebuster = "?" + Date.now();
       callback(null, {
         city: lookup.city,
-        radarMap: mapLookup[lookup.state] ? mapLookup[lookup.state] : null
+        radarMap: mapLookup[lookup.state] ? mapLookup[lookup.state] + cachebuster : null
       });
     }
   };

--- a/modules/accuweatherradar.js
+++ b/modules/accuweatherradar.js
@@ -75,7 +75,7 @@ function Radar() {
       error.status = 404;
       callback(error, null);
     } else {
-      var cachebuster = "?" + Date.now();
+      var cachebuster = "?cb=" + Date.now();
       callback(null, {
         city: lookup.city,
         radarMap: mapLookup[lookup.state] ? mapLookup[lookup.state] + cachebuster : null

--- a/test/accuweatherradarTests.js
+++ b/test/accuweatherradarTests.js
@@ -9,7 +9,7 @@ describe('accuweatherradar', function() {
         assert(!err);
         //verify data was looked up correctly
         assert.strictEqual(res.city, 'Schenectady');
-        assert.ok(/http\:\/\/sirocco\.accuweather\.com\/nx_mosaic_640x480_public\/sir\/inmasirny_\.gif\?[0-1]+/.test(res.radarMap));
+        assert.ok(/http\:\/\/sirocco\.accuweather\.com\/nx_mosaic_640x480_public\/sir\/inmasirny_\.gif\?cb\=[0-1]+/.test(res.radarMap));
         done();
       });
     });

--- a/test/accuweatherradarTests.js
+++ b/test/accuweatherradarTests.js
@@ -10,7 +10,6 @@ describe('accuweatherradar', function() {
         //verify data was looked up correctly
         assert.strictEqual(res.city, 'Schenectady');
         assert.ok(/http\:\/\/sirocco\.accuweather\.com\/nx_mosaic_640x480_public\/sir\/inmasirny_\.gif\?[0-1]+/.test(res.radarMap));
-        //assert.strictEqual(res.radarMap, 'http://sirocco.accuweather.com/nx_mosaic_640x480_public/sir/inmasirny_.gif');
         done();
       });
     });

--- a/test/accuweatherradarTests.js
+++ b/test/accuweatherradarTests.js
@@ -9,7 +9,8 @@ describe('accuweatherradar', function() {
         assert(!err);
         //verify data was looked up correctly
         assert.strictEqual(res.city, 'Schenectady');
-        assert.strictEqual(res.radarMap, 'http://sirocco.accuweather.com/nx_mosaic_640x480_public/sir/inmasirny_.gif');
+        assert.ok(/http\:\/\/sirocco\.accuweather\.com\/nx_mosaic_640x480_public\/sir\/inmasirny_\.gif\?[0-1]+/.test(res.radarMap));
+        //assert.strictEqual(res.radarMap, 'http://sirocco.accuweather.com/nx_mosaic_640x480_public/sir/inmasirny_.gif');
         done();
       });
     });


### PR DESCRIPTION
Added cache buster query param to radar image so it will not be cached by slack, refer to issue #1.
