### PR TITLE
NOAA Radar Map Module

### DIFF
--- a/modules/noaaradar.js
+++ b/modules/noaaradar.js
@@ -85,7 +85,9 @@ function Radar() {
   };
 
   this.getNationalRadar = function (callback) {
-    callback(null, mapLookup.NATL + "?cb=" + Date.now());
+    callback(null, {
+        radarMap: mapLookup.NATL + "?cb=" + Date.now()
+    });
   }
 }
 

--- a/modules/noaaradar.js
+++ b/modules/noaaradar.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var zipcodes = require('zipcodes');
+
+var mapLookup = {
+  AL: "http://radar.weather.gov/ridge/Conus/Loop/southmissvly_loop.gif",
+  AK: "http://radar.weather.gov/ridge/Conus/Loop/NatLoop_Small.gif",
+  AZ: "http://radar.weather.gov/ridge/Conus/Loop/southrockies_loop.gif",
+  AR: "http://radar.weather.gov/ridge/Conus/Loop/southmissvly_loop.gif",
+  CA: "http://radar.weather.gov/ridge/Conus/Loop/pacsouthwest_loop.gif",
+  CO: "http://radar.weather.gov/ridge/Conus/Loop/northrockies_loop.gif",
+  CT: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  DE: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  DC: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  FL: "http://radar.weather.gov/ridge/Conus/Loop/southeast_loop.gif",
+  GA: "http://radar.weather.gov/ridge/Conus/Loop/southeast_loop.gif",
+  HI: "http://radar.weather.gov/ridge/Conus/Loop/NatLoop_Small.gif",
+  ID: "http://radar.weather.gov/ridge/Conus/Loop/pacnorthwest_loop.gif",
+  IL: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  IN: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  IA: "http://radar.weather.gov/ridge/Conus/Loop/uppermissvly_loop.gif",
+  KS: "http://radar.weather.gov/ridge/Conus/Loop/uppermissvly_loop.gif",
+  KY: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  LA: "http://radar.weather.gov/ridge/Conus/Loop/southmissvly_loop.gif",
+  ME: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  MD: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  MA: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  MI: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  MN: "http://radar.weather.gov/ridge/Conus/Loop/uppermissvly_loop.gif",
+  MS: "http://radar.weather.gov/ridge/Conus/Loop/southmissvly_loop.gif",
+  MO: "http://radar.weather.gov/ridge/Conus/Loop/uppermissvly_loop.gif",
+  MT: "http://radar.weather.gov/ridge/Conus/Loop/northrockies_loop.gif",
+  NE: "http://radar.weather.gov/ridge/Conus/Loop/uppermissvly_loop.gif",
+  NV: "http://radar.weather.gov/ridge/Conus/Loop/pacsouthwest_loop.gif",
+  NH: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  NJ: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  NM: "http://radar.weather.gov/ridge/Conus/Loop/southrockies_loop.gif",
+  NY: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  NC: "http://radar.weather.gov/ridge/Conus/Loop/southeast_loop.gif",
+  ND: "http://radar.weather.gov/ridge/Conus/Loop/uppermissvly_loop.gif",
+  OH: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  OK: "http://radar.weather.gov/ridge/Conus/Loop/southplains_loop.gif",
+  OR: "http://radar.weather.gov/ridge/Conus/Loop/pacnorthwest_loop.gif",
+  PA: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  RI: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  SC: "http://radar.weather.gov/ridge/Conus/Loop/southeast_loop.gif",
+  SD: "http://radar.weather.gov/ridge/Conus/Loop/uppermissvly_loop.gif",
+  TN: "http://radar.weather.gov/ridge/Conus/Loop/southeast_loop.gif",
+  TX: "http://radar.weather.gov/ridge/Conus/Loop/southplains_loop.gif",
+  UT: "http://radar.weather.gov/ridge/Conus/Loop/northrockies_loop.gif",
+  VT: "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif",
+  VA: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  WA: "http://radar.weather.gov/ridge/Conus/Loop/pacnorthwest_loop.gif",
+  WV: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  WI: "http://radar.weather.gov/ridge/Conus/Loop/centgrtlakes_loop.gif",
+  WY: "http://radar.weather.gov/ridge/Conus/Loop/northrockies_loop.gif",
+  NATL: "http://radar.weather.gov/ridge/Conus/Loop/NatLoop_Small.gif"
+};
+
+function Radar() {
+
+  /*
+   * If this constructor is called without the "new" operator, "this" points
+   * to the global object. Log a warning and call it correctly.
+   */
+  if (false === (this instanceof Radar)) {
+    console.log('Warning: Radar constructor called without "new" operator');
+    return new Radar();
+  }
+
+  this.getRadarByZip = function (zip, callback) {
+    var lookup = zipcodes.lookup(zip);
+
+    if (!lookup) {
+      var error = new Error('Could not find zipcode');
+      error.status = 404;
+      callback(error, null);
+    } else {
+      var cachebuster = "?cb=" + Date.now();
+      callback(null, {
+        city: lookup.city,
+        radarMap: mapLookup[lookup.state] ? mapLookup[lookup.state] + cachebuster : null
+      });
+    }
+  };
+
+  this.getNationalRadar = function (callback) {
+    callback(null, mapLookup.NATL + "?cb=" + Date.now());
+  }
+}
+
+module.exports = Radar;

--- a/modules/noaaradar.js
+++ b/modules/noaaradar.js
@@ -88,7 +88,7 @@ function Radar() {
     callback(null, {
         radarMap: mapLookup.NATL + "?cb=" + Date.now()
     });
-  }
+  };
 }
 
 module.exports = Radar;

--- a/routes/api.js
+++ b/routes/api.js
@@ -84,7 +84,25 @@ router.post('/forecast', function(req, res, next) {
 router.post('/radar', function(req, res, next) {
   var tokens = req.body.text.split(/\s+/);
   var zip = tokens[0];
-  if (!zip || !isValidUSZip(zip.trim())) {
+  if (!zip && radar.getNationalRadar) {
+    radar.getNationalRadar(function handleResponse(err, result) {
+      if (err || !result.radarMap) {
+        res.json({
+          text: "I'm sorry I couldn't process your request.  Please try again later"
+        });
+      } else {
+        res.json({
+          response_type: "in_channel",
+          attachments: [{
+            title: 'Here\'s the national radar map',
+            pretext: util.format('National Radar Map <%s>', result.radarMap),
+            image_url: result.radarMap,
+            color: "#F35A00"
+          }]
+        });
+      }
+    });
+  } else if (!zip || !isValidUSZip(zip.trim())) {
     res.json({
       text: "I'm sorry I didn't understand.  Please use a US zip"
     });

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Weather = require('../modules/openweathermap');
-var Radar = require('../modules/accuweatherradar');
+var Radar = require('../modules/noaaradar');
 var express = require('express');
 var util = require('util');
 var moment = require('moment');

--- a/test/apiTests.js
+++ b/test/apiTests.js
@@ -54,6 +54,11 @@ describe('slack-weather api', function() {
         });
       }
     };
+    this.getNationalRadar = function (callback) {
+        callback(null, {
+            radarMap: "http://example.org"
+        });
+    };
   };
 
   before(function() {
@@ -250,13 +255,19 @@ describe('slack-weather api', function() {
         }, done);
     });
 
-    it('validates empty zip code', function(done) {
+    it('gets national radar map if zip code is empty', function(done) {
       request(app).post('/v1/radar')
         .send({
           text: ""
         })
         .expect(200, {
-          text: "I'm sorry I didn't understand.  Please use a US zip"
+          response_type: "in_channel",
+          attachments: [{
+            color: "#F35A00",
+            image_url: "http://example.org",
+            pretext: "National Radar Map <http://example.org>",
+            title: "Here\'s the national radar map"
+          }]
         }, done);
     });
 

--- a/test/apiTests.js
+++ b/test/apiTests.js
@@ -61,6 +61,7 @@ describe('slack-weather api', function() {
     mockery.warnOnUnregistered(false);
     mockery.registerMock('../modules/openweathermap', stubbedOWM);
     mockery.registerMock('../modules/accuweatherradar', stubbedRadar);
+    mockery.registerMock('../modules/noaaradar', stubbedRadar);
     app = require('../app.js');
   });
 

--- a/test/noaaradarTests.js
+++ b/test/noaaradarTests.js
@@ -1,0 +1,49 @@
+'use strict';
+
+describe('noaaradar', function() {
+  var radar = new require('../modules/noaaradar')();
+  var assert = require('assert');
+  describe('getRadarByZip', function() {
+    it('gets the radar map for a zip', function(done) {
+      radar.getRadarByZip('12345', function(err, res) {
+        assert(!err);
+        //verify data was looked up correctly
+        assert.strictEqual(res.city, 'Schenectady');
+        assert.ok(/^http:\/\/radar.weather.gov\/ridge\/Conus\/Loop\/northeast_loop.gif\?cb=[0-9]+$/.test(res.radarMap));
+        done();
+      });
+    });
+
+    it('gets returns a null map when map can\'t be located', function(done) {
+      radar.getRadarByZip('00921', function(err, res) {
+        assert(!err);
+        //verify data was looked up correctly
+        assert.strictEqual(res.city, 'San Juan');
+        assert.strictEqual(res.radarMap, null);
+        done();
+      });
+    });
+
+
+    it('returns error on bad zip', function(done) {
+      radar.getRadarByZip('0000', function(err) {
+        assert(err);
+        //verify data was looked up correctly
+        assert.strictEqual(err.status, 404);
+        assert.strictEqual(err.message, 'Could not find zipcode');
+        done();
+      });
+    });
+  });
+
+  describe('getNationalRadar', function () {
+    it('gets the national weather map', function(done) {
+      radar.getNationalRadar(function (err, res) {
+        assert(!err);
+        //verify data was looked up correctly
+        assert.ok(/^http:\/\/radar.weather.gov\/ridge\/Conus\/Loop\/NatLoop_Small.gif\?cb=[0-9]+$/.test(res.radarMap));
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Added NOAA radar map module to replace accuweather
- Radar map images use cache buster query param to stop slack from caching images
- Calling the /radar command without a zip code will return the national weather map
