### PR TITLE
Removed cachebuster from image URL

### DIFF
--- a/modules/noaaradar.js
+++ b/modules/noaaradar.js
@@ -76,17 +76,18 @@ function Radar() {
       error.status = 404;
       callback(error, null);
     } else {
-      var cachebuster = "?cb=" + Date.now();
       callback(null, {
         city: lookup.city,
-        radarMap: mapLookup[lookup.state] ? mapLookup[lookup.state] + cachebuster : null
+        radarMap: mapLookup[lookup.state] ? mapLookup[lookup.state] : null,
+        cacheBuster: Date.now()
       });
     }
   };
 
   this.getNationalRadar = function (callback) {
     callback(null, {
-        radarMap: mapLookup.NATL + "?cb=" + Date.now()
+        radarMap: mapLookup.NATL,
+        cacheBuster: Date.now()
     });
   };
 }

--- a/routes/api.js
+++ b/routes/api.js
@@ -96,7 +96,7 @@ router.post('/radar', function(req, res, next) {
           attachments: [{
             title: 'Here\'s the national radar map',
             pretext: util.format('National Radar Map <%s>', result.radarMap),
-            image_url: result.radarMap,
+            image_url: result.radarMap + (result.cacheBuster ? "?cb=" + result.cacheBuster : ""),
             color: "#F35A00"
           }]
         });
@@ -122,7 +122,7 @@ router.post('/radar', function(req, res, next) {
           attachments: [{
             title: util.format('Here\'s the radar for %s', result.city),
             pretext: util.format('Radar Map for %s <%s>', result.city, result.radarMap),
-            image_url: result.radarMap,
+            image_url: result.radarMap + (result.cacheBuster ? "?cb=" + result.cacheBuster : ""),
             color: "#F35A00"
           }]
         });

--- a/test/apiTests.js
+++ b/test/apiTests.js
@@ -56,7 +56,8 @@ describe('slack-weather api', function() {
     };
     this.getNationalRadar = function (callback) {
         callback(null, {
-            radarMap: "http://example.org"
+            radarMap: "http://example.org",
+            cacheBuster: "1234"
         });
     };
   };
@@ -264,7 +265,7 @@ describe('slack-weather api', function() {
           response_type: "in_channel",
           attachments: [{
             color: "#F35A00",
-            image_url: "http://example.org",
+            image_url: "http://example.org?cb=1234",
             pretext: "National Radar Map <http://example.org>",
             title: "Here\'s the national radar map"
           }]

--- a/test/noaaradarTests.js
+++ b/test/noaaradarTests.js
@@ -9,7 +9,8 @@ describe('noaaradar', function() {
         assert(!err);
         //verify data was looked up correctly
         assert.strictEqual(res.city, 'Schenectady');
-        assert.ok(/^http:\/\/radar.weather.gov\/ridge\/Conus\/Loop\/northeast_loop.gif\?cb=[0-9]+$/.test(res.radarMap));
+        assert.strictEqual(res.radarMap, "http://radar.weather.gov/ridge/Conus/Loop/northeast_loop.gif");
+        assert.ok(/^[0-9]+$/.test(res.cacheBuster));
         done();
       });
     });
@@ -41,7 +42,8 @@ describe('noaaradar', function() {
       radar.getNationalRadar(function (err, res) {
         assert(!err);
         //verify data was looked up correctly
-        assert.ok(/^http:\/\/radar.weather.gov\/ridge\/Conus\/Loop\/NatLoop_Small.gif\?cb=[0-9]+$/.test(res.radarMap));
+        assert.strictEqual(res.radarMap, "http://radar.weather.gov/ridge/Conus/Loop/NatLoop_Small.gif");
+        assert.ok(/^[0-9]+$/.test(res.cacheBuster));
         done();
       });
     });


### PR DESCRIPTION
Previously the cachebuster query param was appended to the image URL and showed up in the chat message. In order to hide the param from the chat message, moved it into the result object so the router could determine whether to display it or not.

![Example](http://i.imgur.com/tQOdNyY.png)
